### PR TITLE
define fully qualified urls for jq

### DIFF
--- a/index/jq
+++ b/index/jq
@@ -1,5 +1,5 @@
-latest linux_amd64 http://stedolan.github.io/jq/download/linux64/jq 89c7bb6138fa6a5c989aca6b71586acc
-latest darwin_amd64 http://stedolan.github.io/jq/download/osx64/jq 086ddfa932021e98bf967aff74badafe
+latest linux_amd64 https://github.com/stedolan/jq/releases/download/jq-1.4/jq-linux-x86_64 89c7bb6138fa6a5c989aca6b71586acc
+latest darwin_amd64 https://github.com/stedolan/jq/releases/download/jq-1.4/jq-osx-x86_64 086ddfa932021e98bf967aff74badafe
 
-1.4 linux_amd64 http://stedolan.github.io/jq/download/linux64/jq 89c7bb6138fa6a5c989aca6b71586acc
-1.4 darwin_amd64 http://stedolan.github.io/jq/download/osx64/jq 086ddfa932021e98bf967aff74badafe
+1.4 linux_amd64 https://github.com/stedolan/jq/releases/download/jq-1.4/jq-linux-x86_64 89c7bb6138fa6a5c989aca6b71586acc
+1.4 darwin_amd64 https://github.com/stedolan/jq/releases/download/jq-1.4/jq-osx-x86_64 086ddfa932021e98bf967aff74badafe


### PR DESCRIPTION
Looks like the jq changed its download links:
instead of adding binaries to gh-pages they point to gh-releases instead.

Actually its good, but they broke the old urls. Than its made backward compatible,
but only for linux: https://github.com/stedolan/jq/commit/e7d1f3ee89d33e42b1360e5eb00d93b80827f1bb

```
curl -sI  http://stedolan.github.io/jq/download/osx64/jq|head -1
HTTP/1.1 404 Not Found
```
