### PR TITLE
sed 4.2.2 binaries added

### DIFF
--- a/index/sed
+++ b/index/sed
@@ -1,0 +1,7 @@
+# install: mv sed $PREFIX/bin
+
+latest linux_amd64 https://github.com/sequenceiq/docker-gnused-linux-bin/releases/download/v4.2.2/sed-linux-4.2.2.tgz a9404833974aea2356e2c984d30fed9e
+latest darwin_amd64 https://github.com/sequenceiq/gnused-osx-bin/releases/download/v4.2.2/sed-darwin-4.2.2.tgz f0fb77edffd31acfa0e2916ba87f7f1a
+
+4.2.2 linux_amd64 https://github.com/sequenceiq/docker-gnused-linux-bin/releases/download/v4.2.2/sed-linux-4.2.2.tgz a9404833974aea2356e2c984d30fed9e
+4.2.2 darwin_amd64 https://github.com/sequenceiq/gnused-osx-bin/releases/download/v4.2.2/sed-darwin-4.2.2.tgz f0fb77edffd31acfa0e2916ba87f7f1a


### PR DESCRIPTION
I was hit several times by old sed versions. The default OS X sed version is really non-standard,
but using alpine or busy box docker images has issues.

To build gnu sed 4.2.2 on OS X brew is the easiest way. For building static binary for linux alpine is used.

Travis supports OS X as build environment, unfortunately in that case docker _service_ is unavailable.
So two separate gh repo releases holding the artifacts:
- https://github.com/sequenceiq/docker-gnused-linux-bin 
- https://github.com/sequenceiq/gnused-osx-bin
